### PR TITLE
Adds jpeg to the upm dependencies

### DIFF
--- a/meta-iot2000-example/recipes-example/mraa/upm_%.bbappend
+++ b/meta-iot2000-example/recipes-example/mraa/upm_%.bbappend
@@ -2,6 +2,7 @@
 #Also we upgrade to version 1.0.1 to fit the mraa version
 
 PV="1.0.1"
+DEPENDS += "jpeg"
 
 SRC_URI = "git://github.com/intel-iot-devkit/upm.git"
 SRCREV="a2698fd560c9fa7917de33a65601bea50d218481"


### PR DESCRIPTION
upm is missing jpeg as a dependency. This issue appeared in the "do_rootfs" step of a custom image.
opkg complained about it.

This fixes it by added jpeg to DEPENDS of the upm recipe.