### PR TITLE
bsp: Fix dependency of image on acpi-upgrades

### DIFF
--- a/meta-iot2000-bsp/conf/machine/iot2000.conf
+++ b/meta-iot2000-bsp/conf/machine/iot2000.conf
@@ -32,5 +32,4 @@ IMAGE_INSTALL_append = " kernel-modules"
 # Package compatiblity:
 PACKAGE_EXTRA_ARCHS_append = " intel-quark quark i586 x86"
 
-EXTRA_IMAGEDEPENDS_append = " acpi-upgrades"
 INITRD_LIVE_prepend = "${DEPLOY_DIR_IMAGE}/acpi-upgrades-${MACHINE}.cpio "

--- a/meta-iot2000-bsp/recipes-core/images/core-image-iot2000.inc
+++ b/meta-iot2000-bsp/recipes-core/images/core-image-iot2000.inc
@@ -1,3 +1,6 @@
 require wic-image.inc
 
+DEPENDS += "acpi-upgrades"
+do_bootimg[depends] += "acpi-upgrades:do_deploy"
+
 IMAGE_INSTALL_append = " switchmode"


### PR DESCRIPTION
Let the image properly depend on acpi-upgrades so that required
artifacts are available in time. We need an explicit dependency of the
do_bootimg on the deployment of acpi-upgrades because the cpio file is
only available after that.

Reported by a user in the support forum and reproduced at the end via a
single-threaded build.

Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>