### PR TITLE
Added node-red init script

### DIFF
--- a/meta-iot2000-example/recipes-example/iot2000setup/files/iot2000setup.py
+++ b/meta-iot2000-example/recipes-example/iot2000setup/files/iot2000setup.py
@@ -544,7 +544,7 @@ class SoftwareSettings:
 		taskReturn = task.stdout.read().decode().lstrip().rstrip()
 		sshEnabled = "running" in taskReturn
 
-		noderedAutostartEnabled = os.path.isfile("/etc/init.d/launch_node-red.sh")
+		noderedAutostartEnabled = os.path.isfile("/etc/rc2.d/S20node-red")
 		mosquittoAutostartEnabled = os.path.isfile("/etc/init.d/launch_mosquitto.sh")
 
 		bb = ButtonBar(self.topmenu.gscreen, [("Done", "done", "ESC")])
@@ -566,15 +566,15 @@ class SoftwareSettings:
 
 		if (noderedAutostartEnabled != noderedAutostartEnabledNew):
 			if ("Auto Start node-red" in selectedOptions):
-				self.registerLaunchScript("on", "launch_node-red.sh", "#!/bin/sh\nsu root -c \"/usr/bin/node /usr/lib/node_modules/node-red/red >/dev/null\" &")
+				self.changeRunCommands("on", "node-red")
 			else:
-				self.registerLaunchScript("off", "launch_node-red.sh", "")
+				self.changeRunCommands("off", "node-red")
 
 		if (sshEnabled != sshEnabledNew):
 			if ("SSH Server Enabled" in selectedOptions):
-				changeSshServerSetting("on")
+				self.changeRunCommands("on", "sshd")
 			else:
-				changeSshServerSetting("off")
+				self.changeRunCommands("off", "sshd")
 
 		if (mosquittoAutostartEnabled != mosquittoAutostartEnabledNew):
 			if ("Auto Start Mosquitto Broker" in selectedOptions):
@@ -587,13 +587,13 @@ class SoftwareSettings:
 			else:
 				self.registerLaunchScript("off", "launch_mosquitto.sh", "")
 
-	def changeSshServerSetting(self, status):
+	def changeRunCommands(self, status, script):
 		if (status == "on"):
-			subprocess.call("update-rc.d -f sshd defaults", shell=True, stdout=open(os.devnull, 'wb'))
-			subprocess.call("/etc/init.d/sshd start", shell=True, stdout=open(os.devnull, 'wb'))
+			subprocess.call("update-rc.d " + script + " defaults", shell=True, stdout=open(os.devnull, 'wb'))
+			subprocess.call("/etc/init.d/" + script + " start", shell=True, stdout=open(os.devnull, 'wb'))
 		elif (status == "off"):
-			subprocess.call("/etc/init.d/sshd stop", shell=True, stdout=open(os.devnull, 'wb'))
-			subprocess.call("update-rc.d -f sshd remove", shell=True, stdout=open(os.devnull, 'wb'))
+			subprocess.call("/etc/init.d/" + script + " stop", shell=True, stdout=open(os.devnull, 'wb'))
+			subprocess.call("update-rc.d -f " + script + " remove", shell=True, stdout=open(os.devnull, 'wb'))
 	def registerLaunchScript(self, status, fileName, scriptcontent):
 		if (status == "on"):
 			initFile = open("/etc/init.d/" + fileName, 'w')

--- a/meta-iot2000-example/recipes-example/iot2000setup/files/node-red
+++ b/meta-iot2000-example/recipes-example/iot2000setup/files/node-red
@@ -1,0 +1,67 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:             Node-RED
+# Required-Start:       $remote_fs $time
+# Required-Stop:        $remote_fs $time
+# Default-Start:        2 3 4 5
+# Default-Stop:         0 1 6
+# Short-Description:    Node-RED
+### END INIT INFO
+
+# To enable autostart use command:
+# $ chmod +x /etc/init.d/node-red
+# $ update-rc.d node-red defaults
+
+# To disable autostart use command:
+# $ update-rc.d -f node-red remove
+
+NODEJS=/usr/bin/node
+NODERED=/usr/lib/node_modules/node-red/red
+LOGFILE=/var/log/node-red.log
+PIDFILE=/run/node-red.pid
+HOME=/home/root/
+
+case "$1" in
+  start)
+    echo -n "Starting Node-RED: "
+    if [ -n "$(pgrep -F $PIDFILE 2> /dev/null)" ]; then
+      echo "already running as pid $PID"
+    else
+      $NODEJS $NODERED >> $LOGFILE &
+      echo $! > $PIDFILE
+      echo "logging to $LOGFILE"
+    fi
+    ;;
+  stop)
+    echo -n "Stopping Node-RED: "
+    if [ -f $PIDFILE ]; then
+      if [ -n "$(pgrep -F $PIDFILE 2> /dev/null)" ]; then
+        /usr/bin/pkill -SIGINT -F $PIDFILE
+        for i in {0..59}; do
+          if [ -n "$(pgrep -F $PIDFILE 2> /dev/null)" ]; then
+            sleep 1
+            echo -n "."
+          else
+            rm $PIDFILE
+            echo "done"
+            break
+          fi
+        done
+      else
+        echo "not running"
+      fi
+    else
+      echo "no pid file"
+    fi
+    ;;
+  restart)
+    $0 stop
+    $0 start
+    ;;
+  *)
+    echo "Usage: $0 { start | stop | restart }" >&2
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/meta-iot2000-example/recipes-example/iot2000setup/iot2000setup_1.0.bb
+++ b/meta-iot2000-example/recipes-example/iot2000setup/iot2000setup_1.0.bb
@@ -4,11 +4,12 @@ LIC_FILES_CHKSUM = "file://${IOT2000_MIT_LICENSE};md5=838c366f69b72c5df05c96dff7
 
 inherit update-rc.d
 
-SRC_URI = "file://expandfs.sh file://iot2000setup.py"
+SRC_URI = "file://expandfs.sh file://iot2000setup.py file://node-red"
 
 FILES_${PN} += " \
 	${sysconfdir}/init.d/expandfs.sh \
 	${bindir}/iot2000setup \
+	${sysconfdir}/init.d/node-red \
 "
 
 RDEPENDS_${PN} += "libnewt-python python3-mraa"
@@ -20,4 +21,5 @@ do_install() {
    install -d ${D}${bindir}
    install -m 0755 ${WORKDIR}/iot2000setup.py ${D}${bindir}/iot2000setup
    install -m 0755 ${WORKDIR}/expandfs.sh ${D}${sysconfdir}/init.d/expandfs.sh
+   install -m 0755 ${WORKDIR}/node-red ${D}${sysconfdir}/init.d/node-red
 }


### PR DESCRIPTION
I took the liberty of adding a nicer node-red startup script which allows for a log and a clean shutdown signal. Since I do a lot of trainings with this device and teaching industry people how to install a custom start script manually takes a lot of time and patience.

The script has been included into the iot2000setup recipe and I hope I updated the bitbake file correctly.

ps: Also not sure whether I am pushing this to the right branch. Couldn't find a contribution guideline.