### PR TITLE
bsp: Weaken debug-tweaks activation

### DIFF
--- a/kas-bsp.yml
+++ b/kas-bsp.yml
@@ -37,7 +37,7 @@ local_conf_header:
     CONF_VERSION = "1"
 
   debug-tweaks: |
-    EXTRA_IMAGE_FEATURES = "debug-tweaks"
+    EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
 
   diskmon: |
     BB_DISKMON_DIRS = "\


### PR DESCRIPTION
This allows downstream users to overwrite the EXTRA_IMAGE_FEATURES,
disabling debug-tweaks.

Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>