### PR TITLE
bps: linux-cip-rt: Fix inclusion of IOT2000 patches

### DIFF
--- a/meta-iot2000-bsp/recipes-kernel/linux/linux-cip_4.4.bb
+++ b/meta-iot2000-bsp/recipes-kernel/linux/linux-cip_4.4.bb
@@ -7,7 +7,6 @@ require linux-cip_4.4.inc
 FILESEXTRAPATHS_prepend := "${THISDIR}/configs:${THISDIR}/patches:"
 
 SRC_URI += " \
-    ${KERNEL_PATCHES} \
     file://defconfig"
 
 PV = "${LINUX_VERSION}"

--- a/meta-iot2000-bsp/recipes-kernel/linux/linux-cip_4.4.inc
+++ b/meta-iot2000-bsp/recipes-kernel/linux/linux-cip_4.4.inc
@@ -3,7 +3,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 LINUX_VERSION = "4.4.185-cip35"
 SRC_URI = " \
-    https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git/snapshot/linux-cip-${LINUX_VERSION}.tar.gz"
+    https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git/snapshot/linux-cip-${LINUX_VERSION}.tar.gz \
+    ${KERNEL_PATCHES}"
 SRC_URI[sha256sum] = "fcdd46615fdc7e0e4ad3d73465d1489e3af72ed09efb8c748abec7be38586a5b"
 
 KERNEL_PATCHES = " \


### PR DESCRIPTION
Should go in prio to 2.6.0 closing.