### PR TITLE
bsp: linux-cip: Fix linux-libc-headers build, further consolidate rec…

### DIFF
--- a/meta-iot2000-bsp/recipes-kernel/linux/linux-cip-rt_4.4.bb
+++ b/meta-iot2000-bsp/recipes-kernel/linux/linux-cip-rt_4.4.bb
@@ -4,13 +4,10 @@ SECTION = "kernel"
 require recipes-kernel/linux/linux-yocto.inc
 require linux-cip_4.4.inc
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/configs:${THISDIR}/patches:"
-
 LINUX_VERSION .= "-rt24"
 SRC_URI += " \
     file://rt-0001-spi-pca2xx-pci-Allow-MSI.patch \
     file://rt-0002-gpio-dwapb-Work-around-RT-full-s-enforced-IRQ-thread.patch \
-    file://defconfig \
     file://iot2000-cip-rt.scc"
 SRC_URI[sha256sum] = "44721ced14d1171ad5b110c4a4a4d15327b962b7ef0187891a513547f2ddde22"
 

--- a/meta-iot2000-bsp/recipes-kernel/linux/linux-cip_4.4.bb
+++ b/meta-iot2000-bsp/recipes-kernel/linux/linux-cip_4.4.bb
@@ -4,11 +4,6 @@ SECTION = "kernel"
 require recipes-kernel/linux/linux-yocto.inc
 require linux-cip_4.4.inc
 
-FILESEXTRAPATHS_prepend := "${THISDIR}/configs:${THISDIR}/patches:"
-
-SRC_URI += " \
-    file://defconfig"
-
 PV = "${LINUX_VERSION}"
 
 LINUX_VERSION_EXTENSION = ""

--- a/meta-iot2000-bsp/recipes-kernel/linux/linux-cip_4.4.inc
+++ b/meta-iot2000-bsp/recipes-kernel/linux/linux-cip_4.4.inc
@@ -1,9 +1,12 @@
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/configs:${THISDIR}/patches:"
+
 LINUX_VERSION = "4.4.185-cip35"
 SRC_URI = " \
     https://git.kernel.org/pub/scm/linux/kernel/git/cip/linux-cip.git/snapshot/linux-cip-${LINUX_VERSION}.tar.gz \
+    file://defconfig \
     ${KERNEL_PATCHES}"
 SRC_URI[sha256sum] = "fcdd46615fdc7e0e4ad3d73465d1489e3af72ed09efb8c748abec7be38586a5b"
 


### PR DESCRIPTION
…ipes

Previous commit broke linux-libc-headers_4.4.bb which got the full set
patches without the path. Fix that by moving FILESEXTRAPATHS_prepend
over.

Also move the common defconfig at this chance.

Signed-off-by: Jan Kiszka <jan.kiszka@siemens.com>