### PR TITLE
example: iot2000setup: Fix reading of zone1970.tab

### DIFF
--- a/meta-iot2000-example/recipes-example/iot2000setup/files/iot2000setup.py
+++ b/meta-iot2000-example/recipes-example/iot2000setup/files/iot2000setup.py
@@ -152,7 +152,7 @@ class OsSettings:
 		self.finish = True
 
 	def ChangeTimezone(self):
-		with open("/usr/share/zoneinfo/zone1970.tab") as zonetab:
+		with open("/usr/share/zoneinfo/zone1970.tab", encoding="utf-8") as zonetab:
 			zones = [(zone.split()[2], zone.split()[2]) \
 				 for zone in zonetab.readlines() \
 				 if not zone.startswith('#')]


### PR DESCRIPTION
See also https://support.industry.siemens.com/tf/ww/en/posts/problem-with-local-time-iot2040/227688/?page=0&pageSize=10.