### PR TITLE
refactor: improved quality of the lua script, removed duplicate service

### DIFF
--- a/meta-iot2000-example/recipes-core/images/example-image-swu.inc
+++ b/meta-iot2000-example/recipes-core/images/example-image-swu.inc
@@ -8,6 +8,5 @@ IMAGE_ROOTFS_EXTRA_SPACE = "0"
 IMAGE_FSTYPES += "ext4.gz"
 
 IMAGE_INSTALL += "swupdate"
-IMAGE_INSTALL += "swupdate-progress"
 IMAGE_INSTALL += "efibootguard-tools"
 IMAGE_INSTALL += "persiststore"

--- a/meta-iot2000-example/recipes-support/swupdate/swupdate/swupdate_handlers.lua
+++ b/meta-iot2000-example/recipes-support/swupdate/swupdate/swupdate_handlers.lua
@@ -121,10 +121,10 @@ function kernel_handler(image)
     kernelparams = kernelparams:gsub("REPLACEME", newroot)
     kernelfile = bootlabels[rootindex] .. kernelname
 
-    swupdate.info(string.format("Setting bootloader environment: %s=%s", "kernelfile", kernelfile))
+    swupdate.info("Setting bootloader environment: %s=%s", "kernelfile", kernelfile)
     swupdate.set_bootenv("kernelfile", kernelfile)
 
-    swupdate.info(string.format("Setting bootloader environment: %s=%s", "kernelparams", kernelparams))
+    swupdate.info("Setting bootloader environment: %s=%s", "kernelparams", kernelparams)
     swupdate.set_bootenv("kernelparams", kernelparams)
 
     return 0


### PR DESCRIPTION
Lua function string.format() inside the scripts are not needed anymore since [commit](https://github.com/sbabic/swupdate/commit/ad25dc066880d0d79f66737685c83003597c018f). 
Removed the the swupdate-progress client, due to the already included process client **progress_firmware**.

Signed-off-by: Heiko Schabert <heiko.schabert@siemens.com>