### PR TITLE
Add Yocto layer denpendencies in bblayers.conf

### DIFF
--- a/meta-iot2000-bsp/conf/layer.conf
+++ b/meta-iot2000-bsp/conf/layer.conf
@@ -8,6 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "iot2000-bsp"
 BBFILE_PATTERN_iot2000-bsp = "^${LAYERDIR}/"
 BBFILE_PRIORITY_iot2000-bsp = "6"
+LAYERDEPENDS_iot2000-bsp = "meta meta-poky meta-yocto-bsp meta-efibootguard meta-oe"
 
 LAYERSERIES_COMPAT_iot2000-bsp = "dunfell"
 

--- a/meta-iot2000-example/conf/layer.conf
+++ b/meta-iot2000-example/conf/layer.conf
@@ -8,10 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "iot2000-example"
 BBFILE_PATTERN_iot2000-example = "^${LAYERDIR}/"
 BBFILE_PRIORITY_iot2000-example = "6"
-
-LAYERDEPENDS_iot2000-example += " \
-	iot2000-bsp \
-	"
+LAYERDEPENDS_iot2000-example = "iot2000-bsp meta-networking meta-python meta-swupdate"
 
 LAYERSERIES_COMPAT_iot2000-example = "dunfell"
 


### PR DESCRIPTION
Yocto layer dependencies aren't managed in this project and the dependency issue is transparent to users because kas insure that necessary layers are present before launching Yocto. However, it's important that layer dependencies are managed by native Yocto tools because not every Yocto project is using kas. So this enables as to include these layers in other Yocto projects without dependency issues.