### PR TITLE
Fix: Image inclusion usage correction.

### DIFF
--- a/meta-iot2000-bsp/recipes-core/images/core-image-minimal-iot2000.bb
+++ b/meta-iot2000-bsp/recipes-core/images/core-image-minimal-iot2000.bb
@@ -1,1 +1,2 @@
+require core-image-minimal.bb
 require core-image-iot2000.inc

--- a/meta-iot2000-bsp/recipes-core/images/core-image-rt.bb
+++ b/meta-iot2000-bsp/recipes-core/images/core-image-rt.bb
@@ -1,4 +1,4 @@
-require recipes-core/images/core-image-minimal.bb
+require recipes-core/images/core-image-minimal-iot2000.bb
 require core-image-iot2000.inc
 
 # Skip processing of this recipe if linux-cip-rt is not explicitly specified as the

--- a/meta-iot2000-example/recipes-core/images/iot2000-example-image.bb
+++ b/meta-iot2000-example/recipes-core/images/iot2000-example-image.bb
@@ -1,3 +1,3 @@
-require recipes-core/images/core-image-minimal.bb
+require recipes-core/images/core-image-minimal-iot2000.bb
 require recipes-core/images/core-image-iot2000.inc
 require iot2000-example-image.inc


### PR DESCRIPTION
Images should never be bbappended (.bbappend) because image recipies are included (with "require") in other image recipes and "require" feature don't guarantee .bbappend files incluson which can lead to unexpected behaviour. So the good practice is to define new recipe for each image then include it in other images recipe if needed.